### PR TITLE
ircd: remove specific references to CFV-165

### DIFF
--- a/ircd/m_links.c
+++ b/ircd/m_links.c
@@ -119,7 +119,7 @@ int m_links(struct Client* cptr, struct Client* sptr, int parc, char* parv[])
   {
     send_reply(sptr, RPL_ENDOFLINKS, parc < 2 ? "*" : parv[1]);
     sendcmdto_one(&me, CMD_NOTICE, sptr, "%C :%s %s", sptr,
-                  "/LINKS has been disabled, from CFV-165.  Visit ", 
+                  "/LINKS has been disabled.  Visit ",
                   feature_str(FEAT_HIS_URLSERVERS));
     return 0;
   }

--- a/ircd/m_map.c
+++ b/ircd/m_map.c
@@ -174,7 +174,7 @@ int m_map(struct Client* cptr, struct Client* sptr, int parc, char* parv[])
   if (feature_bool(FEAT_HIS_MAP) && !IsAnOper(sptr))
   {
     sendcmdto_one(&me, CMD_NOTICE, sptr, "%C :%s %s", sptr,
-                  "/MAP has been disabled, from CFV-165.  "
+                  "/MAP has been disabled.  "
                   "Visit ", feature_str(FEAT_HIS_URLSERVERS));
     return 0;
   }


### PR DESCRIPTION
This Undernet jargon doesn't really make sense for other networks that have /map and /links disabled.