### PR TITLE
Change numerics used for RPL_INVITELIST/RPL_ENDOFINVITELIST/RPL_WHOISBOT/RPL_WHOISACCOUNTONLY

### DIFF
--- a/doc/features.txt
+++ b/doc/features.txt
@@ -178,8 +178,8 @@ INVITE list:
  invite to (ie: an invite to a channel which you haven't joined)
  
  Additional Numerics:
-  RPL_INVITELIST      346
-  RPL_ENDOFINVITELIST 347
+  RPL_INVITELIST      336
+  RPL_ENDOFINVITELIST 337
 
 NICK change:
  Version: Since the dawn of time.

--- a/include/numeric.h
+++ b/include/numeric.h
@@ -245,8 +245,7 @@ extern const struct Numeric* get_error_numeric(int err);
                                            RPL_WHOISOPERATOR/RPL_WHOISIDLE */
 #define RPL_WHOISCHANNELS    319
 /*      RPL_WHOIS_HIDDEN     320         Anothernet +h, ick! */
-/*	RPL_WHOISSPECIAL     320	unreal */
-#define RPL_WHOISSPECIAL     320
+#define RPL_WHOISSPECIAL     320        /* Unreal extension; also used to indicate +r to others */
 #define RPL_LISTSTART        321
 #define RPL_LIST             322
 #define RPL_LISTEND          323
@@ -266,8 +265,9 @@ extern const struct Numeric* get_error_numeric(int err);
 #define RPL_LISTUSAGE        334        /* Undernet extension */
 /*	RPL_COMMANDSYNTAX    334	   Dalnet */
 /*	RPL_LISTSYNTAX	     334	   unreal */
-#define RPL_WHOISACCOUNTONLY 335	/* Nefarious extension */
-#define RPL_WHOISBOT         336	/* Nefarious extension */
+#define RPL_WHOISBOT         335	/* Unreal extension */
+#define RPL_INVITELIST       336        /* ircd-hybrid extension */
+#define RPL_ENDOFINVITELIST  337        /* ircd-hybrid extension */
 /*      RPL_CHANPASSOK       338           IRCnet extension (?)*/
 #define	RPL_WHOISACTUALLY    338	/* Undernet extension, dalnet */
 /*	RPL_BADCHANPASS	     339           IRCnet extension (?) */
@@ -278,8 +278,8 @@ extern const struct Numeric* get_error_numeric(int err);
 #define RPL_WHOISKILL        343        /* Nefarious extension */
 
 #define RPL_ISSUEDINVITE     345        /* Undernet extension */
-#define RPL_INVITELIST       346        /* IRCnet, Undernet extension */
-#define RPL_ENDOFINVITELIST  347        /* IRCnet, Undernet extension */
+#define RPL_INVEXLIST        346        /* Reply to "MODE +I", RFC2812 calls it RPL_INVITELIST */
+#define RPL_ENDOFINVEXLIST   347        /* Reply to "MODE +I", RFC2812 calls it RPL_ENDOFINVITELIST */
 #define RPL_EXCEPTLIST       348        /* IRCnet/Nefarious extension */
 #define RPL_ENDOFEXCEPTLIST  349        /* IRCnet/Nefarious extension */
 

--- a/ircd/m_whois.c
+++ b/ircd/m_whois.c
@@ -259,7 +259,7 @@ static void do_whois(struct Client* sptr, struct Client *acptr, int parc)
       send_reply(sptr, RPL_WHOISSERVICE, name, feature_str(FEAT_WHOIS_SERVICE));
 
     if (IsAccountOnly(acptr) && !IsPrivDeaf(acptr))
-      send_reply(sptr, RPL_WHOISACCOUNTONLY, name);
+      send_reply(sptr, RPL_WHOISSPECIAL, "only accepts messages from registered users");
 
     if (IsPrivDeaf(acptr))
       send_reply(sptr, RPL_WHOISPRIVDEAF, name);

--- a/ircd/s_err.c
+++ b/ircd/s_err.c
@@ -702,11 +702,11 @@ static Numeric replyTable[] = {
 /* 334 */
   { RPL_LISTUSAGE, ":%s", "334" },
 /* 335 */
-  { RPL_WHOISACCOUNTONLY, "%s :only accepts messages from registered users", "335" },
+  { RPL_WHOISBOT, "%s :is a bot", "335" },
 /* 336 */
-  { RPL_WHOISBOT, "%s :is a bot", "336" },
+  { RPL_INVITELIST, ":%s", "336" },
 /* 337 */
-  { 0 },
+  { RPL_ENDOFINVITELIST, ":End of Invite List", "337" },
 /* 338 */
   { RPL_WHOISACTUALLY, "%s %s@%s %s :Actual user@host, Actual IP", "338" },
 /* 339 */
@@ -724,9 +724,9 @@ static Numeric replyTable[] = {
 /* 345 */
   { RPL_ISSUEDINVITE, "%s %s %s :%s has been invited by %s", "345" },
 /* 346 */
-  { RPL_INVITELIST, ":%s", "346" },
+  { 0 },
 /* 347 */
-  { RPL_ENDOFINVITELIST, ":End of Invite List", "347" },
+  { 0 },
 /* 348 */
   { RPL_EXCEPTLIST, "%s %s %s %Tu", "348" },
 /* 349 */


### PR DESCRIPTION
1. Use 336/337 instead of 346/347 to reply to 'INVITE' commands

  RFC2812 defines `RPL_INVITELIST` (346) and `RPL_ENDOFINVITELIST` (347) numerics,
  but they are only to be used for replies to 'MODE +I', which stands for
  'invite exemption' (though it is, surprisingly, not defined in RFC2812
  itself). An they must have two params: the channel and mask
  <https://datatracker.ietf.org/doc/html/rfc2812#page-46>.

  Instead, the consensus is to use 336 and 337 to reply to parameter-less
  INVITE messages; and call these `RPL_INVITELIST`/`RPL_ENDOFINVITELIST`,
  while the RFC2812 numerics should be renamed to something like
  `RPL_INVEXLIST`/`RPL_ENDOFINVEXLIST` (which ircu2 does not use, so it
  does not matter much). See for example:

  * https://github.com/inspircd/inspircd/commit/df17d47b6a17ee6214f7f501e3b9d73cb8acd36e
  * https://github.com/unrealircd/unrealircd/commit/a11e6df64b9ab8fe27ecbc1300893bf8796dcebc

2. Unfortunately, this triggered a game of musical chairs, so I changed
   RPL_WHOISBOT from 336 to 335, for consistency with Hybrid.
   This then collided with RPL_WHOISACCOUNTONLY.
   As RPL_WHOISACCOUNTONLY is unique to Nefarious, I decided to make it
   use RPL_WHOISSPECIAL (used for custom WHOIS strings) instead of
   introducin a new Nefarious-specific numeric.