### PR TITLE
Fix handling of 'WHOWAS <nick> 0'

### DIFF
--- a/ircd/m_whowas.c
+++ b/ircd/m_whowas.c
@@ -150,7 +150,7 @@ int m_whowas(struct Client* cptr, struct Client* sptr, int parc, char* parv[])
         cur++;
         found++;
       }
-      if (max >= 0 && cur >= max)
+      if (max >= 1 && cur >= max)
         break;
     }
     if (!found)


### PR DESCRIPTION
According to both RFCs, 'If a non-positive number is passed as being
<count>, then a full search is done'

https://datatracker.ietf.org/doc/html/rfc1459#section-4.5.3
https://datatracker.ietf.org/doc/html/rfc2812#section-3.6.3

But before this commit, Nefarious returned exactly one result instead.

This is how other implementations do it (including ircu2,
since https://github.com/UndernetIRC/ircu2/pull/19 )