### PR TITLE
kick: Use the nick of the kicker instead of kickee as default comment

### DIFF
--- a/ircd/m_kick.c
+++ b/ircd/m_kick.c
@@ -158,8 +158,11 @@ int m_kick(struct Client *cptr, struct Client *sptr, int parc, char *parv[])
 	OpLevel(member2), OpLevel(member), "kick",
 	OpLevel(member) == OpLevel(member2) ? "the same" : "a higher");
 
-  /* We rely on ircd_snprintf to truncate the comment */
-  comment = EmptyString(parv[parc - 1]) ? parv[0] : parv[parc - 1];
+  if (parc > 3)
+    /* We rely on ircd_snprintf to truncate the comment */
+    comment = EmptyString(parv[parc - 1]) ? parv[0] : parv[parc - 1];
+  else
+    comment = parv[0];
 
   if (!IsLocalChannel(name))
     sendcmdto_serv_butone(sptr, CMD_KICK, cptr, "%H %C :%s", chptr, who,


### PR DESCRIPTION
This was already done when passed an empty comment, but not when the
comment is missing.

Additionally, according to [RFC2812](https://datatracker.ietf.org/doc/html/rfc2812#section-3.2.8):

> If a comment is given, this will be sent instead of the default
> message, the nickname of the user issuing the KICK.