### PR TITLE
makepem: Fix equality operator

### DIFF
--- a/tools/makepem/makepem
+++ b/tools/makepem/makepem
@@ -39,7 +39,7 @@ else
     openssl x509 -subject -dates -fingerprint -noout -in $1/ircd.pem
   else
     FileExist=FALSE
-    while [ "$FileExist" == "FALSE" ];
+    while [ "$FileExist" = "FALSE" ];
     do
       echo Please enter in the filname of the SSL certificate including the full path; read sslpath
       if test -f $sslpath


### PR DESCRIPTION
== is a bash-specific extension, but this script's shebang invokes sh, not bash.