### PR TITLE
fix: Give bcrypt mech a real $BCRYPT$ tag, recognize $2x$

### DIFF
--- a/ircd/ircd_crypt.c
+++ b/ircd/ircd_crypt.c
@@ -201,9 +201,9 @@ crypt_mechs_t* crypt_mech;
   return hashed_pass;
  }
 
- /* try bcrypt ($2a$, $2b$, $2y$) - pass directly to system crypt */
+ /* try bcrypt ($2a$, $2b$, $2x$, $2y$) - pass directly to system crypt */
  if (strlen(salt) > 4 && salt[0] == '$' && salt[1] == '2' &&
-     (salt[2] == 'a' || salt[2] == 'b' || salt[2] == 'y') && salt[3] == '$')
+     (salt[2] == 'a' || salt[2] == 'b' || salt[2] == 'x' || salt[2] == 'y') && salt[3] == '$')
  {
    char *s;
    Debug((DEBUG_DEBUG, "ircd_crypt: detected bcrypt hash"));

--- a/ircd/ircd_crypt_bcrypt.c
+++ b/ircd/ircd_crypt_bcrypt.c
@@ -129,7 +129,7 @@ const char* ircd_crypt_bcrypt(const char* key, const char* salt)
 
   /* If salt is already a bcrypt hash/salt, use it directly */
   if (strlen(salt) >= 28 && salt[0] == '$' && salt[1] == '2' &&
-      (salt[2] == 'a' || salt[2] == 'b' || salt[2] == 'y') && salt[3] == '$')
+      (salt[2] == 'a' || salt[2] == 'b' || salt[2] == 'x' || salt[2] == 'y') && salt[3] == '$')
   {
     result = crypt(key, salt);
   }
@@ -177,12 +177,15 @@ void ircd_register_crypt_bcrypt(void)
   crypt_mech->shortname = "crypt_bcrypt";
   crypt_mech->description = "Bcrypt password hash ($2y$).";
   crypt_mech->crypt_function = &ircd_crypt_bcrypt;
-  /* Note: We use an empty token because bcrypt hashes are detected
-   * directly by their $2y$ prefix in ircd_crypt(), not via the
-   * normal token mechanism. This registration is primarily for
-   * umkpasswd to generate bcrypt passwords. */
-  crypt_mech->crypt_token = "";
-  crypt_mech->crypt_token_size = 0;
+  /* Use a real tag so this mech can be selected via the normal token
+   * dispatch loop in ircd_crypt(). An empty token would have matched
+   * any salt (ircd_strncmp with n=0 always returns 0), causing
+   * untagged crypt(3) and libc-crypt formats ($1$, $5$, $6$) to be
+   * dispatched here and re-hashed against a freshly generated salt.
+   * Existing raw $2[aby]$ stored hashes are still verified by the
+   * explicit prefix branch after the dispatch loop. */
+  crypt_mech->crypt_token = "$BCRYPT$";
+  crypt_mech->crypt_token_size = 8;
 
   ircd_crypt_register_mech(crypt_mech);
 }


### PR DESCRIPTION
## Summary

The bcrypt mech in `ircd/ircd_crypt_bcrypt.c` was registered with `crypt_token = ""` and `crypt_token_size = 0`, intending to be selected only via the explicit `$2[aby]$` prefix branch in `ircd_crypt()` rather than the generic token dispatch loop at `ircd/ircd_crypt.c:149-202`. The dispatch loop didn't honor that intent:

- The "salt too short" guard `strlen(salt) < crypt_token_size` never trips for size 0.
- The selector `ircd_strncmp(token, salt, 0)` always returns 0 — comparing zero characters of any two strings always succeeds.

So bcrypt's empty-token entry matched **any** salt that hadn't already matched smd5/plain/native earlier in the loop. The loop returns from inside the matched branch, making the explicit `$2[aby]$` block at line 213 and the post-loop native-crypt fallback at line 227 unreachable.

### Effect

Stored oper passwords in any of these formats hit the bcrypt mech and got re-hashed against a freshly generated bcrypt salt, which can never match the stored value:

- Untagged legacy `crypt(3)` (13-char DES)
- `$1$` (PHK MD5-crypt)
- `$5$` (SHA-256 crypt)
- `$6$` (SHA-512 crypt)

Tagged formats (`$SMD5$`, `$PLAIN$`, `$CRYPT$`) were unaffected because their mechs precede bcrypt in registration order and match first. Stored `$2[aby]$` hashes worked by accident — bcrypt's `crypt_function` recognizes the `$2[aby]$` prefix in the salt argument and uses the stored salt instead of generating a new one.

### Fix

Give the bcrypt mech a real `$BCRYPT$` tag (size 8). With a real tag:

- `$BCRYPT$$2[abxy]$...` (newly tagged hashes from `umkpasswd`) are dispatched through the loop normally.
- Raw `$2[abxy]$...` stored hashes don't match in the loop, fall through to the explicit `$2[abxy]$` branch after the loop, and are verified via `ircd_crypt_native` (system `crypt(3)`).
- `$1$` / `$5$` / `$6$` / untagged `crypt(3)` hashes don't match in the loop, fall through to the post-loop native-crypt fallback, and are verified via system `crypt(3)`.

### Bonus: `$2x$` recognition

Also add `$2x$` to both bcrypt prefix detection sites (`ircd_crypt.c:206` and `ircd_crypt_bcrypt.c:132`). `$2x$` is the legacy buggy-8bit bcrypt variant; system `crypt(3)` supports it where present, but the prefix tests were skipping it. Pre-existing oversight, fixed here while adjacent.

## Test plan

- [ ] Verify oper login with `$1$`-prefixed password (libc MD5-crypt) succeeds
- [ ] Verify oper login with `$SMD5$`-prefixed password still succeeds (regression check)
- [ ] Verify oper login with raw `$2y$`-prefixed password still succeeds (regression check — should hit explicit `$2[abxy]$` branch)
- [ ] Verify oper login with untagged 13-char `crypt(3)` password succeeds (if anyone still has these)
- [ ] Verify wrong password is rejected for each format

🤖 Generated with [Claude Code](https://claude.com/claude-code)
