### PR TITLE
fix: remaining ircd_strncpy off-by-one truncations (account stamp, GeoIP)

### DIFF
--- a/ircd/ircd_geoip.c
+++ b/ircd/ircd_geoip.c
@@ -163,22 +163,22 @@ void geoip_apply(struct Client* cptr)
       if (result.found_entry) {
         status = MMDB_get_value(&result.entry, &entry_data, "country", "iso_code", NULL);
         if ((MMDB_SUCCESS == status) && (entry_data.has_data) && (entry_data.type == MMDB_DATA_TYPE_UTF8_STRING))
-          ircd_strncpy((char *)&cli_countrycode(cptr), entry_data.utf8_string, (entry_data.data_size > 3 ? 3 : entry_data.data_size));
+          ircd_strncpy((char *)&cli_countrycode(cptr), entry_data.utf8_string, (entry_data.data_size + 1 > 3 ? 3 : entry_data.data_size + 1));
         else
           ircd_strncpy((char *)&cli_countrycode(cptr), "--", 3);
         status = MMDB_get_value(&result.entry, &entry_data, "country", "names", "en", NULL);
         if ((MMDB_SUCCESS == status) && (entry_data.has_data) && (entry_data.type == MMDB_DATA_TYPE_UTF8_STRING))
-          ircd_strncpy((char *)&cli_countryname(cptr), entry_data.utf8_string, (entry_data.data_size > 256 ? 256 : entry_data.data_size));
+          ircd_strncpy((char *)&cli_countryname(cptr), entry_data.utf8_string, (entry_data.data_size + 1 > 256 ? 256 : entry_data.data_size + 1));
         else
           ircd_strncpy((char *)&cli_countryname(cptr), "Unknown", 8);
         status = MMDB_get_value(&result.entry, &entry_data, "continent", "code", NULL);
         if ((MMDB_SUCCESS == status) && (entry_data.has_data) && (entry_data.type == MMDB_DATA_TYPE_UTF8_STRING))
-          ircd_strncpy((char *)&cli_continentcode(cptr), entry_data.utf8_string, (entry_data.data_size > 3 ? 3 : entry_data.data_size));
+          ircd_strncpy((char *)&cli_continentcode(cptr), entry_data.utf8_string, (entry_data.data_size + 1 > 3 ? 3 : entry_data.data_size + 1));
         else
           ircd_strncpy((char *)&cli_continentcode(cptr), "--", 3);
         status = MMDB_get_value(&result.entry, &entry_data, "continent", "names", "en", NULL);
         if ((MMDB_SUCCESS == status) && (entry_data.has_data) && (entry_data.type == MMDB_DATA_TYPE_UTF8_STRING))
-          ircd_strncpy((char *)&cli_continentname(cptr), entry_data.utf8_string, (entry_data.data_size > 256 ? 256 : entry_data.data_size));
+          ircd_strncpy((char *)&cli_continentname(cptr), entry_data.utf8_string, (entry_data.data_size + 1 > 256 ? 256 : entry_data.data_size + 1));
         else
           ircd_strncpy((char *)&cli_continentname(cptr), "Unknown", 8);
         SetGeoIP(cptr);

--- a/ircd/m_account.c
+++ b/ircd/m_account.c
@@ -261,7 +261,7 @@ int ms_account(struct Client* cptr, struct Client* sptr, int parc,
       if (type == 'A') {
         SetAccount(acptr);
         ircd_strncpy(cli_user(acptr)->account, cli_loc(acptr)->account,
-                        ACCOUNTLEN);
+                        ACCOUNTLEN + 1);
 
         if (parc > 4) {
           cli_user(acptr)->acc_create = atoi(parv[4]);


### PR DESCRIPTION
Follow-up to the `ircd_strncpy` strlcpy-semantics change (cf09cec4) and the off-by-one sweep in #85. Two call sites were still passing the old "max chars" value instead of the full buffer size, so they truncate by one character. Both are live on `master`.

### 1. `m_account.c` — LOC account stamp (user-visible, production)
The `type=='A'` login-on-connect account-accept path copied `cli_loc(acptr)->account` → `cli_user(acptr)->account` with a bare `ACCOUNTLEN`, while the other three `ircd_strncpy(..., ACCOUNTLEN)` calls in the file were already updated to `ACCOUNTLEN + 1`.

With `ACCOUNTLEN=15` and `account[ACCOUNTLEN + 1]`, the bare value now copies only 14 bytes, so an account name of **exactly 15 characters** loses its last character. Shorter names hit the source NUL first, which is why it only reproduced for max-length LOC accounts.

Observed on AfterNET: `DefinitelyHuman` (15 chars) stamped as `DefinitelyHuma`, producing `unknown account stamp` warnings from services.

### 2. `ircd_geoip.c` — MMDB strings (latent, MMDB builds only)
`ircd_geoip.c` was never updated for the new semantics. The four MMDB branches in `geoip_apply()` pass `entry_data.data_size` as the size. MMDB's `utf8_string` is **not** NUL-terminated and `data_size` is the exact byte length, so copying with `n = data_size` drops the final byte: `US` → `U`, `United States` → `United State` (same for continent code/name). Fixed to `data_size + 1`, still capped at the destination size. The legacy `USE_GEOIP`, static-string, and `geoip_apply_mark` calls use NUL-terminated sources and were already correct.

### Audit note
A paren-balanced sweep of all 171 `ircd_strncpy` call sites was done (single-line grep misses the `m_account.c` case because the size arg wraps to the next line). After these two, all remaining sites pass a full buffer size (`LEN+1`/`sizeof`) or an intentional exact-length copy. No other stragglers found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)