### PR TITLE
shun: defer add-time ident match when client's USER hasn't landed

### DIFF
--- a/ircd/shun.c
+++ b/ircd/shun.c
@@ -218,6 +218,34 @@ do_shun(struct Client *cptr, struct Client *sptr, struct Shun *shun)
             continue;
         Debug((DEBUG_DEBUG,"Matched!"));
       } else { /* Host/IP shun */
+        /* Defer when the client's username isn't known yet (pre-USER
+         * mid-registration — cli_user is allocated by make_user on
+         * first input, but cli_user->username[] isn't populated until
+         * the USER command is parsed in register_user).  We can't
+         * evaluate the ident half of a user@host mask without it; any
+         * guard on the *shape* of sh_user (`starts with *', `looks
+         * specific', etc.) leaves edge cases broken (`?*', `?bob',
+         * `*foo' which is "ends with foo" not "matches anything",
+         * etc.) — so the rule is just "defer unless we know the mask
+         * matches any ident."
+         *
+         * The only safe known-match-any shortcut is the literal
+         * single bare `*' — explicitly check sh_user[0]=='*' &&
+         * sh_user[1]=='\0' so patterns that start with star but have
+         * trailing chars (e.g. `*foo') don't short-circuit.  This
+         * preserves Jobe's original intent (a `*@host' shun applies
+         * pre-USER, useful when no identd is running) while closing
+         * the false-positive class where a `bob@*' shun previously
+         * fired for any mid-registration client.
+         *
+         * Post-registration shun_lookup invoked from m_privmsg/etc.
+         * re-evaluates the shun once the client's USER lands, so the
+         * deferral has no enforcement consequence — the only
+         * artefact it suppresses is the spurious SNO_GLINE "Shun
+         * active for ..." oper notice for the wrong user. */
+        if (!*(cli_user(acptr)->username)
+            && !(shun->sh_user[0] == '*' && shun->sh_user[1] == '\0'))
+          continue;
         if (*(cli_user(acptr)->username) &&
             match(shun->sh_user, (cli_user(acptr))->username) != 0)
           continue;


### PR DESCRIPTION
## Summary

Fixes a long-standing false-positive in `do_shun` (the retroactive
shun-apply loop run at SHUN add time) where the ident half of a
`user@host` mask was bypassed for any client mid-registration.

A guard at `ircd/shun.c:221-223` (introduced in 2019 by f3179734)
short-circuited the whole ident match on empty `cli_user->username`,
which is the case for every client between `make_user()` (allocates
`cli_user` on first input) and `register_user()` (populates
`username` from the USER command).  Result: a shun like `bob@*` would
match every mid-registration client, and the server emitted a
spurious `SNO_GLINE` "Shun active for <victim>" oper notice
attributing the shun to a user whose ident doesn't (yet) match.

The fix inverts the guard: always defer pre-USER, except when
`sh_user` is the literal single bare `*` (the only shape we can prove
matches any ident).  The explicit `sh_user[1] == '\0'` check is
needed so non-bare patterns that lead with `*` (e.g. `*foo` = "ends
with foo") don't sneak through the shortcut.

## Behaviour preserved

- `*@host` shuns still apply pre-USER (the original "no identd
  running" use case — Jobe's intent in the 2019 guard).

## Behaviour fixed

- `bob@*`, `*foo@*`, `?bob@*`, `?*@*`, and every other pattern with a
  specific ident half no longer false-positive against
  mid-registration clients.

## No enforcement consequence

`shun_lookup` invoked from `m_privmsg`/etc. re-evaluates the shun
once the client's USER lands and its ident match runs unconditionally
there.  This patch only fixes the add-time apply loop's mirror
behaviour — what it suppresses is the spurious oper-side notice for
the wrong user.

## Test plan

Verified against an integration testnet (MrLenin/testnet) with
[5 vitest cases](https://github.com/MrLenin/testnet/blob/main/tests/src/ircv3/shun-ident-defer.test.ts) covering:

- [x] Pre-USER client + `bob@*` mask → no false-positive (the bug)
- [x] Registered + non-matching ident → no false-positive (regression)
- [x] Registered + matching ident → matches (sanity)
- [x] Pre-USER + `*foo@*` mask → deferred (`*foo` is "ends with foo", not match-any)
- [x] Pre-USER + `?bob@*` mask → deferred (`?bob` is "char-then-bob", not match-any)

All 5 pass against the patched build.