### PR TITLE
WebSocket: fix plain-port handshake, inbound frame cap, and large upgrade requests (#97, #98, #99)

### DIFF
--- a/include/client.h
+++ b/include/client.h
@@ -50,6 +50,9 @@
 #include "ssl.h"
 #endif
 #endif /* USE_SSL */
+#ifndef INCLUDED_websocket_h
+#include "websocket.h"          /* WS_MAX_FRAME */
+#endif
 
 struct ConfItem;
 struct Listener;
@@ -460,7 +463,7 @@ struct Connection
   unsigned char       con_labeled_batch; /**< 1 if labeled_batch_start opened a batch */
   struct ForwardedLabel con_fwd_labels[MAX_FORWARDED_LABELS]; /**< Forwarded label FIFO */
   /* WebSocket state for RFC 6455 compliance */
-  unsigned char       con_ws_frame_buf[FULL_MSG_SIZE]; /**< Partial WebSocket frame buffer */
+  unsigned char       con_ws_frame_buf[WS_MAX_FRAME]; /**< Partial WebSocket frame buffer (holds one max-size frame) */
   int                 con_ws_frame_len;   /**< Length of data in frame buffer */
   char                con_ws_frag_buf[16384]; /**< Fragment reassembly buffer */
   int                 con_ws_frag_len;    /**< Length of data in fragment buffer */

--- a/include/client.h
+++ b/include/client.h
@@ -468,6 +468,8 @@ struct Connection
   char                con_ws_frag_buf[16384]; /**< Fragment reassembly buffer */
   int                 con_ws_frag_len;    /**< Length of data in fragment buffer */
   int                 con_ws_frag_opcode; /**< Opcode of first fragment */
+  char*               con_ws_hs_buf;      /**< HTTP upgrade request being accumulated (heap, WS_HANDSHAKE_MAX + 1; freed once the handshake is decided) */
+  int                 con_ws_hs_len;      /**< Bytes in con_ws_hs_buf */
   time_t              con_burst_gate_deadline; /**< Deadline at which to force-release a
                                                   burst gate held on a non-BXF-aware (legacy)
                                                   peer.  Only meaningful while IsBurstGated().
@@ -687,6 +689,10 @@ struct Client {
 #define cli_ws_frag_len(cli)	con_ws_frag_len(cli_connect(cli))
 /** Get WebSocket first fragment opcode. */
 #define cli_ws_frag_opcode(cli)	con_ws_frag_opcode(cli_connect(cli))
+/** Get WebSocket handshake accumulation buffer. */
+#define cli_ws_hs_buf(cli)	con_ws_hs_buf(cli_connect(cli))
+/** Get WebSocket handshake accumulation buffer length. */
+#define cli_ws_hs_len(cli)	con_ws_hs_len(cli_connect(cli))
 /** Get per-class recv classifier state. */
 #define cli_recv_state(cli)     con_recv_state(cli_connect(cli))
 /** Get tag-region byte count for the in-flight wire line. */
@@ -998,6 +1004,10 @@ struct Client {
 #define con_ws_frag_len(con)	((con)->con_ws_frag_len)
 /** Get WebSocket first fragment opcode. */
 #define con_ws_frag_opcode(con)	((con)->con_ws_frag_opcode)
+/** Get WebSocket handshake accumulation buffer. */
+#define con_ws_hs_buf(con)	((con)->con_ws_hs_buf)
+/** Get WebSocket handshake accumulation buffer length. */
+#define con_ws_hs_len(con)	((con)->con_ws_hs_len)
 /** Get per-class recv classifier state. */
 #define con_recv_state(con)     ((con)->con_recv_state)
 /** Get tag-region byte count for the in-flight wire line. */

--- a/include/websocket.h
+++ b/include/websocket.h
@@ -46,6 +46,14 @@ struct Client;
  * (a negative value distinct from the generic -1 protocol error). */
 #define WS_DECODE_TOOBIG (-2)
 
+/** Largest HTTP upgrade request we will accumulate before giving up.
+ * Browsers send 500-700 bytes routinely and a few KB with cookies. */
+#define WS_HANDSHAKE_MAX 8192
+
+/** websocket_handshake_feed() return value when the request exceeded
+ * WS_HANDSHAKE_MAX without a terminating blank line. */
+#define WS_HANDSHAKE_TOOBIG (-2)
+
 /** Handle WebSocket handshake for a new connection.
  * @param[in] cptr Client attempting to connect.
  * @param[in] buffer Raw data received.
@@ -53,6 +61,19 @@ struct Client;
  * @return 1 if handshake completed successfully, 0 if more data needed, -1 on error.
  */
 extern int websocket_handshake(struct Client *cptr, const char *buffer, int length);
+
+/** Accumulate an HTTP upgrade request across reads and run the handshake
+ * once the terminating blank line has arrived.
+ * @param[in] cptr Client attempting to connect.
+ * @param[in] data Bytes just read.
+ * @param[in] len Number of bytes in \a data.
+ * @param[out] consumed Number of bytes of \a data that belonged to the
+ *   request; anything after them is already WebSocket frame data.
+ * @return 1 if the handshake completed, 0 if more data is needed, -1 if
+ *   the handshake failed, WS_HANDSHAKE_TOOBIG if the request is too big.
+ */
+extern int websocket_handshake_feed(struct Client *cptr, const char *data,
+                                    int len, int *consumed);
 
 /** Decode a WebSocket frame and extract the payload.
  * @param[in] frame Raw WebSocket frame data.

--- a/include/websocket.h
+++ b/include/websocket.h
@@ -32,6 +32,20 @@ struct Client;
 #define WS_OPCODE_PING         0x9
 #define WS_OPCODE_PONG         0xA
 
+/** Largest data-frame payload accepted from a client, in bytes.  Frames
+ * over this are answered with Close 1009 (Message Too Big).  Callers of
+ * websocket_decode_frame() must hand it a buffer larger than this. */
+#define WS_MAX_PAYLOAD 16384
+
+/** Largest complete client frame: 2-byte header + 8-byte extended length
+ * + 4-byte mask + WS_MAX_PAYLOAD.  Sizes the per-connection buffer that
+ * holds a partial frame between reads. */
+#define WS_MAX_FRAME   (WS_MAX_PAYLOAD + 14)
+
+/** websocket_decode_frame() return value for a frame over WS_MAX_PAYLOAD
+ * (a negative value distinct from the generic -1 protocol error). */
+#define WS_DECODE_TOOBIG (-2)
+
 /** Handle WebSocket handshake for a new connection.
  * @param[in] cptr Client attempting to connect.
  * @param[in] buffer Raw data received.
@@ -48,7 +62,8 @@ extern int websocket_handshake(struct Client *cptr, const char *buffer, int leng
  * @param[out] payload_len Length of decoded payload.
  * @param[out] opcode The frame opcode.
  * @param[out] is_fin Set to 1 if FIN bit is set (final fragment), 0 otherwise.
- * @return Number of bytes consumed from frame, 0 if incomplete, -1 on error.
+ * @return Number of bytes consumed from frame, 0 if incomplete, -1 on
+ *   error, WS_DECODE_TOOBIG if the payload exceeds WS_MAX_PAYLOAD.
  */
 extern int websocket_decode_frame(const unsigned char *frame, int frame_len,
                                   char *payload, int payload_size,
@@ -73,5 +88,13 @@ extern int websocket_encode_frame(const char *data, int data_len,
  */
 extern int websocket_handle_control(struct Client *cptr, int opcode,
                                     const char *payload, int payload_len);
+
+/** Send a WebSocket Close frame with a status code (best effort).
+ * @param[in] cptr Client connection.
+ * @param[in] code RFC 6455 status code (e.g. 1009 Message Too Big).
+ * @param[in] reason Optional short reason text (truncated to 123 bytes).
+ */
+extern void websocket_send_close(struct Client *cptr, int code,
+                                 const char *reason);
 
 #endif /* INCLUDED_websocket_h */

--- a/ircd/list.c
+++ b/ircd/list.c
@@ -184,6 +184,12 @@ static void dealloc_connection(struct Connection* con)
   DBufClear(&(con_recvQ(con)));
   if (con_listener(con))
     release_listener(con_listener(con));
+  /* Client went away in the middle of a WebSocket upgrade request */
+  if (con_ws_hs_buf(con)) {
+    MyFree(con_ws_hs_buf(con));
+    con_ws_hs_buf(con) = NULL;
+    con_ws_hs_len(con) = 0;
+  }
 
   --connections.inuse;
 

--- a/ircd/s_auth.c
+++ b/ircd/s_auth.c
@@ -125,25 +125,20 @@ struct AuthRequest {
   char deferred_nick[NICKLEN + 1]; /**< nick deferred due to bouncer ghost collision */
 };
 
-/** Array of message text (with length) pairs for AUTH status
- * messages.  Indexed using #ReportType.
+/** Array of AUTH status message texts (CRLF is added by msgq).
+ * Indexed using #ReportType.
  */
-static struct {
-  const char*  message;
-  unsigned int length;
-} HeaderMessages [] = {
-#define MSG(STR) { STR, sizeof(STR) - 1 }
-  MSG("NOTICE * :*** Looking up your hostname\r\n"),
-  MSG("NOTICE * :*** Found your hostname\r\n"),
-  MSG("NOTICE * :*** Couldn't look up your hostname\r\n"),
-  MSG("NOTICE * :*** Checking Ident\r\n"),
-  MSG("NOTICE * :*** Got ident response\r\n"),
-  MSG("NOTICE * :*** No ident response\r\n"),
-  MSG("NOTICE * :*** \r\n"),
-  MSG("NOTICE * :*** Your forward and reverse DNS do not match, "
-    "ignoring hostname.\r\n"),
-  MSG("NOTICE * :*** Invalid hostname\r\n")
-#undef MSG
+static const char* HeaderMessages [] = {
+  "NOTICE * :*** Looking up your hostname",
+  "NOTICE * :*** Found your hostname",
+  "NOTICE * :*** Couldn't look up your hostname",
+  "NOTICE * :*** Checking Ident",
+  "NOTICE * :*** Got ident response",
+  "NOTICE * :*** No ident response",
+  "NOTICE * :*** ",
+  "NOTICE * :*** Your forward and reverse DNS do not match, "
+    "ignoring hostname.",
+  "NOTICE * :*** Invalid hostname"
 };
 
 /** Enum used to index messages in the HeaderMessages[] array. */
@@ -159,14 +154,20 @@ typedef enum {
   REPORT_INVAL_DNS
 } ReportType;
 
-/** Sends response \a r (from #ReportType) to client \a c. */
-#ifdef USE_SSL
+/** Sends response \a r (from #ReportType) to client \a c.
+ *
+ * Always goes through the client's sendQ (msgq appends the CRLF).
+ * This used to be a raw write() on plain sockets, which bypassed the
+ * IsWSNeedHandshake()/IsWSSniff() hold in deliver_it() and put bare
+ * IRC lines on the wire ahead of the HTTP 101 on plain-text WebSocket
+ * ports.  Queuing it means the hold applies, and once the handshake
+ * completes the notices are delivered as proper WebSocket frames.  For
+ * ordinary plain IRC ports the sendQ is flushed immediately, so the
+ * behaviour there is unchanged.
+ */
 #define sendheader(c, r) \
-   ssl_send(c, HeaderMessages[(r)].message, HeaderMessages[(r)].length)
-#else
-#define sendheader(c, r) \
-   send(cli_fd(c), HeaderMessages[(r)].message, HeaderMessages[(r)].length, 0)
-#endif /* USE_SSL */
+   do { sendrawto_one((c), "%s", HeaderMessages[(r)]); \
+        send_queued(c); } while (0)
 
 /** Enumeration of IAuth connection flags. */
 enum IAuthFlag

--- a/ircd/s_bsd.c
+++ b/ircd/s_bsd.c
@@ -1078,43 +1078,48 @@ ssl_read_again:
      */
     if (IsWSNeedHandshake(cptr)) {
       int result;
-      char *client_buffer;
-      char *endp;
-      const char *src;
+      int consumed;
 
       Debug((DEBUG_DEBUG, "Client WebSocket handshake: length=%d", length));
 
-      /* Accumulate data in client buffer for HTTP request */
-      client_buffer = cli_buffer(cptr);
-      endp = client_buffer + cli_count(cptr);
-      src = readbuf;
+      /*
+       * The request is accumulated in a per-connection buffer of up to
+       * WS_HANDSHAKE_MAX bytes (browsers send 500-700 byte requests,
+       * more than cli_buffer holds) and the handshake runs once the
+       * blank line arrives, however many reads that takes.
+       */
 
-      /* Copy incoming data to buffer */
-      while (length > 0 && (endp - client_buffer) < BUFSIZE - 1) {
-        *endp++ = *src++;
-        length--;
+      /* The sniff step above may have parked up to 3 bytes in
+       * cli_buffer; they are the start of the request.  Too short to
+       * complete anything, so the result is not interesting. */
+      if (cli_count(cptr) > 0) {
+        (void)websocket_handshake_feed(cptr, cli_buffer(cptr), cli_count(cptr),
+                                       &consumed);
+        cli_count(cptr) = 0;
       }
-      *endp = '\0';
-      cli_count(cptr) = endp - client_buffer;
 
-      /* Try to complete handshake */
-      result = websocket_handshake(cptr, client_buffer, cli_count(cptr));
+      result = websocket_handshake_feed(cptr, readbuf, length, &consumed);
       if (result == 0) {
         /* Need more data */
         return 1;
+      } else if (result == WS_HANDSHAKE_TOOBIG) {
+        return exit_client(cptr, cptr, &me, "WebSocket handshake too large");
       } else if (result < 0) {
         /* Handshake failed */
         return exit_client(cptr, cptr, &me, "WebSocket handshake failed");
       }
-      /* Handshake succeeded - clear buffer and unblock sends */
+      /* Handshake succeeded - unblock sends */
       Debug((DEBUG_DEBUG, "WebSocket handshake completed successfully"));
-      cli_count(cptr) = 0;
       ClrFlag(cptr, FLAG_BLOCKED);  /* Allow queued messages to be sent */
       /* Trigger send of queued data */
       send_queued(cptr);
-      /* If no remaining data, we're done for now */
+      /* Anything after the request in this read is already WebSocket
+       * frame data: move it to the front of readbuf for the decoder
+       * below instead of dropping it. */
+      length -= consumed;
       if (length <= 0)
         return 1;
+      memmove(readbuf, readbuf + consumed, length);
     }
 
     /*

--- a/ircd/s_bsd.c
+++ b/ircd/s_bsd.c
@@ -1123,41 +1123,71 @@ ssl_read_again:
      * Supports RFC 6455 fragmentation and partial frame buffering.
      */
     if (length > 0 && IsWebSocket(cptr)) {
-      char ws_payload[BUFSIZE + 16];  /* Stack-local, not static */
-      int ws_len, opcode, consumed, is_fin;
+      /* Decode buffer.  The decoder rejects any payload >= the buffer
+       * size, so this must be larger than WS_MAX_PAYLOAD (the largest
+       * frame it accepts) plus the '\n' appended below.  Static rather
+       * than stack: 16 KB is too much stack, and read_packet() is not
+       * reentrant anyway (readbuf is static too). */
+      static char ws_payload[WS_MAX_PAYLOAD + 2];
+      int ws_len = 0, opcode = 0, consumed, is_fin = 0;
       unsigned char *ws_data;
       int ws_remaining;
       int copy_len;
+      const char *src = readbuf;
+      int src_len = length;
 
       Debug((DEBUG_DEBUG, "WebSocket receive: length=%d, IsWebSocket=%d", length, IsWebSocket(cptr)));
 
-      /* Prepend any partial frame from previous read */
-      if (cli_ws_frame_len(cptr) > 0) {
-        copy_len = length;
-        if (copy_len > BUFSIZE - cli_ws_frame_len(cptr))
-          copy_len = BUFSIZE - cli_ws_frame_len(cptr);
-        memcpy(cli_ws_frame_buf(cptr) + cli_ws_frame_len(cptr), readbuf, copy_len);
-        ws_data = cli_ws_frame_buf(cptr);
-        ws_remaining = cli_ws_frame_len(cptr) + copy_len;
-      } else {
-        ws_data = (unsigned char *)readbuf;
-        ws_remaining = length;
-      }
+      /*
+       * All input goes through the per-connection frame buffer, which
+       * holds exactly one maximum-size frame (WS_MAX_FRAME).  readbuf
+       * (SERVER_TCP_WINDOW) can be much larger than that, so the loop
+       * below tops the frame buffer up from readbuf whenever it holds
+       * no complete frame, decodes what it can, and repeats until the
+       * read is drained.  A frame split across reads is thus reassembled
+       * whatever its size, and bytes after a completed frame are never
+       * dropped.
+       */
+      ws_data = cli_ws_frame_buf(cptr);
+      ws_remaining = cli_ws_frame_len(cptr);
 
-      while (ws_remaining > 0) {
-        consumed = websocket_decode_frame(ws_data, ws_remaining,
-                                          ws_payload, sizeof(ws_payload),
-                                          &ws_len, &opcode, &is_fin);
-        Debug((DEBUG_DEBUG, "WebSocket decode: consumed=%d, ws_len=%d, opcode=%d, is_fin=%d, remaining=%d",
-               consumed, ws_len, opcode, is_fin, ws_remaining));
+      while (ws_remaining > 0 || src_len > 0) {
+        consumed = 0;
+        if (ws_remaining > 0) {
+          consumed = websocket_decode_frame(ws_data, ws_remaining,
+                                            ws_payload, sizeof(ws_payload),
+                                            &ws_len, &opcode, &is_fin);
+          Debug((DEBUG_DEBUG, "WebSocket decode: consumed=%d, ws_len=%d, opcode=%d, is_fin=%d, remaining=%d",
+                 consumed, ws_len, opcode, is_fin, ws_remaining));
+        }
         if (consumed == 0) {
-          /* Incomplete frame - save for next read */
-          Debug((DEBUG_DEBUG, "WebSocket: Incomplete frame, saving %d bytes", ws_remaining));
-          if (ws_remaining > 0 && ws_remaining < BUFSIZE) {
-            memmove(cli_ws_frame_buf(cptr), ws_data, ws_remaining);
-            cli_ws_frame_len(cptr) = ws_remaining;
+          /* Incomplete frame (or empty buffer): pull in more of the read */
+          if (src_len <= 0) {
+            Debug((DEBUG_DEBUG, "WebSocket: Incomplete frame, saving %d bytes", ws_remaining));
+            break;  /* tail is saved after the loop */
           }
-          break;
+          if (ws_remaining > 0 && ws_data != cli_ws_frame_buf(cptr))
+            memmove(cli_ws_frame_buf(cptr), ws_data, ws_remaining);
+          ws_data = cli_ws_frame_buf(cptr);
+          copy_len = (int)sizeof(cli_ws_frame_buf(cptr)) - ws_remaining;
+          if (copy_len <= 0) {
+            /* Buffer full and still no complete frame.  Cannot happen for
+             * a frame the decoder accepts (WS_MAX_FRAME covers the largest
+             * header plus WS_MAX_PAYLOAD), so treat it as a protocol error
+             * rather than spin. */
+            return exit_client(cptr, cptr, &me, "WebSocket frame error");
+          }
+          if (copy_len > src_len)
+            copy_len = src_len;
+          memcpy(cli_ws_frame_buf(cptr) + ws_remaining, src, copy_len);
+          ws_remaining += copy_len;
+          src += copy_len;
+          src_len -= copy_len;
+          continue;
+        } else if (consumed == WS_DECODE_TOOBIG) {
+          /* Over WS_MAX_PAYLOAD: tell the client why before dropping it */
+          websocket_send_close(cptr, 1009, "Message too big");
+          return exit_client(cptr, cptr, &me, "WebSocket message too big");
         } else if (consumed < 0) {
           /* Frame error */
           Debug((DEBUG_DEBUG, "WebSocket: Frame error (consumed=%d)", consumed));
@@ -1165,7 +1195,6 @@ ssl_read_again:
         }
 
         Debug((DEBUG_DEBUG, "WebSocket frame payload: '%.50s'", ws_payload));
-        cli_ws_frame_len(cptr) = 0;  /* Frame consumed successfully */
 
         /* Handle control frames (always complete, can be interleaved) */
         if (opcode >= WS_OPCODE_CLOSE) {
@@ -1260,6 +1289,11 @@ ssl_read_again:
         ws_data += consumed;
         ws_remaining -= consumed;
       }
+
+      /* Keep any partial frame at the front of the buffer for the next read */
+      if (ws_remaining > 0 && ws_data != cli_ws_frame_buf(cptr))
+        memmove(cli_ws_frame_buf(cptr), ws_data, ws_remaining);
+      cli_ws_frame_len(cptr) = ws_remaining;
       length = 0; /* Data processed via WebSocket path */
     }
 

--- a/ircd/test/Makefile.in
+++ b/ircd/test/Makefile.in
@@ -26,9 +26,11 @@ CMOCKA_TESTPROGS = \
 	ircd_crypt_cmocka \
 	crule_cmocka \
 	history_cmocka \
-	recv_classify_cmocka
+	recv_classify_cmocka \
+	websocket_cmocka
 
 CMOCKA_LIBS = -lcmocka
+SSL_LIBS = -lssl -lcrypto
 ZSTD_LIBS = -lzstd
 
 DEP_SRC = \
@@ -48,6 +50,7 @@ DEP_SRC = \
 	crule_cmocka.c \
 	history_cmocka.c \
 	recv_classify_cmocka.c \
+	websocket_cmocka.c \
 	test_stub.c
 
 all: ${TESTPROGS}
@@ -142,6 +145,12 @@ history_cmocka: $(HISTORY_CMOCKA_OBJS)
 RECV_CLASSIFY_CMOCKA_OBJS = recv_classify_cmocka.o test_stub.o ../recv_classify.o
 recv_classify_cmocka: $(RECV_CLASSIFY_CMOCKA_OBJS)
 	${CC} -o $@ $(LDFLAGS) $(RECV_CLASSIFY_CMOCKA_OBJS) $(CMOCKA_LIBS)
+
+# websocket tests - frame decoding and handshake accumulation (#98, #99).
+# Includes websocket.c directly with stubs; needs OpenSSL for the accept key.
+WEBSOCKET_CMOCKA_OBJS = websocket_cmocka.o test_stub.o ../ircd_alloc.o ../ircd_string.o
+websocket_cmocka: $(WEBSOCKET_CMOCKA_OBJS)
+	${CC} -o $@ $(LDFLAGS) $(WEBSOCKET_CMOCKA_OBJS) $(CMOCKA_LIBS) $(SSL_LIBS)
 
 .c.o:
 	${CC} ${CFLAGS} ${CPPFLAGS} -c $< -o $@

--- a/ircd/test/websocket_cmocka.c
+++ b/ircd/test/websocket_cmocka.c
@@ -1,0 +1,381 @@
+/*
+ * websocket_cmocka.c - CMocka unit tests for the WebSocket transport.
+ *
+ * Covers the regressions behind evilnet/nefarious2 #98 and #99:
+ *   - websocket_decode_frame() with payloads of 600 bytes and
+ *     WS_MAX_PAYLOAD (16384) when given a WS_MAX_PAYLOAD-sized buffer,
+ *     the WS_DECODE_TOOBIG return one byte over, and the old failure
+ *     mode (a BUFSIZE-sized buffer rejects a 600-byte frame).
+ *   - websocket_handshake_feed() accumulating upgrade requests of 600
+ *     and 2000 bytes across 512-byte reads, handing back bytes that
+ *     follow the request, and rejecting a request over WS_HANDSHAKE_MAX.
+ *
+ * websocket.c is included directly (like ircd_cloaking_cmocka.c) with
+ * stubs for feature_str(), ircd_snprintf() and os_send_nonb().
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <cmocka.h>
+
+#include "../websocket.c"
+
+/* ---- stubs for websocket.c's external dependencies ---- */
+
+const char *feature_str(enum Feature feat)
+{
+  (void)feat;
+  return "";  /* FEAT_WEBSOCKET_ORIGIN: allow all origins */
+}
+
+int ircd_snprintf(struct Client *dest, char *buf, size_t buf_len,
+                  const char *format, ...)
+{
+  va_list args;
+  int ret;
+  (void)dest;
+  va_start(args, format);
+  ret = vsnprintf(buf, buf_len, format, args);
+  va_end(args);
+  return ret;
+}
+
+/* Capture whatever websocket_handshake() writes to the (plain) socket */
+static char sent_buf[1024];
+static int sent_len;
+
+IOResult os_send_nonb(int fd, const char *buf, unsigned int length,
+                      unsigned int *count_out)
+{
+  (void)fd;
+  if (length > sizeof(sent_buf) - 1)
+    length = sizeof(sent_buf) - 1;
+  memcpy(sent_buf, buf, length);
+  sent_buf[length] = '\0';
+  sent_len = length;
+  *count_out = length;
+  return IO_SUCCESS;
+}
+
+/* ---- helpers ---- */
+
+static void setup_client(struct Client *cli, struct Connection *con)
+{
+  memset(cli, 0, sizeof(*cli));
+  memset(con, 0, sizeof(*con));
+  cli_connect(cli) = con;
+  strcpy(cli_sockhost(cli), "test.host");
+  sent_len = 0;
+  sent_buf[0] = '\0';
+}
+
+/* Build a masked client->server frame: FIN | opcode, payload of plen 'x'
+ * bytes.  Returns the frame length. */
+static int build_frame(unsigned char *frame, int opcode, int plen)
+{
+  static const unsigned char mask[4] = { 0x12, 0x34, 0x56, 0x78 };
+  int pos = 0, i;
+
+  frame[pos++] = 0x80 | opcode;
+  if (plen < 126) {
+    frame[pos++] = 0x80 | plen;
+  } else if (plen < 65536) {
+    frame[pos++] = 0x80 | 126;
+    frame[pos++] = (plen >> 8) & 0xFF;
+    frame[pos++] = plen & 0xFF;
+  } else {
+    frame[pos++] = 0x80 | 127;
+    for (i = 7; i >= 0; i--)
+      frame[pos++] = (i < 4) ? ((plen >> (i * 8)) & 0xFF) : 0;
+  }
+  memcpy(frame + pos, mask, 4);
+  pos += 4;
+  for (i = 0; i < plen; i++)
+    frame[pos + i] = ('a' + (i % 26)) ^ mask[i % 4];
+  return pos + plen;
+}
+
+/* Build an upgrade request padded with an X-Pad header to exactly
+ * total_len bytes (including the terminating blank line). */
+static int build_request(char *req, int total_len)
+{
+  static const char head[] =
+    "GET / HTTP/1.1\r\n"
+    "Host: localhost\r\n"
+    "Upgrade: websocket\r\n"
+    "Connection: Upgrade\r\n"
+    "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+    "Sec-WebSocket-Version: 13\r\n"
+    "Sec-WebSocket-Protocol: text.ircv3.net\r\n"
+    "X-Pad: ";
+  static const char tail[] = "\r\n\r\n";
+  int pad = total_len - (int)(sizeof(head) - 1) - (int)(sizeof(tail) - 1);
+
+  assert_true(pad >= 0);
+  memcpy(req, head, sizeof(head) - 1);
+  memset(req + sizeof(head) - 1, 'p', pad);
+  memcpy(req + sizeof(head) - 1 + pad, tail, sizeof(tail) - 1);
+  req[total_len] = '\0';
+  return total_len;
+}
+
+/* Feed 'req' to websocket_handshake_feed() in chunks of 'chunk' bytes,
+ * asserting it wants more until the last chunk.  Returns the final result
+ * and the consumed count of the last call. */
+static int feed_in_chunks(struct Client *cli, const char *req, int len,
+                          int chunk, int *last_consumed)
+{
+  int off = 0, result = 0, consumed = 0;
+
+  while (off < len) {
+    int n = (len - off < chunk) ? len - off : chunk;
+    result = websocket_handshake_feed(cli, req + off, n, &consumed);
+    off += n;
+    if (off < len) {
+      assert_int_equal(result, 0);
+      assert_int_equal(consumed, n);
+    }
+  }
+  *last_consumed = consumed;
+  return result;
+}
+
+/* ========== websocket_decode_frame() (#98) ========== */
+
+static void test_decode_600_byte_frame(void **state)
+{
+  static unsigned char frame[WS_MAX_FRAME];
+  static char payload[WS_MAX_PAYLOAD + 2];
+  int flen, consumed, plen, opcode, fin;
+  (void)state;
+
+  flen = build_frame(frame, WS_OPCODE_TEXT, 600);
+  consumed = websocket_decode_frame(frame, flen, payload, sizeof(payload),
+                                    &plen, &opcode, &fin);
+  assert_int_equal(consumed, flen);
+  assert_int_equal(plen, 600);
+  assert_int_equal(opcode, WS_OPCODE_TEXT);
+  assert_int_equal(fin, 1);
+  assert_int_equal(payload[0], 'a');
+  assert_int_equal(payload[599], 'a' + (599 % 26));
+  assert_int_equal(payload[600], '\0');
+}
+
+static void test_decode_max_payload_frame(void **state)
+{
+  static unsigned char frame[WS_MAX_FRAME];
+  static char payload[WS_MAX_PAYLOAD + 2];
+  int flen, consumed, plen, opcode, fin;
+  (void)state;
+
+  flen = build_frame(frame, WS_OPCODE_BINARY, WS_MAX_PAYLOAD);
+  assert_true(flen <= WS_MAX_FRAME);
+  consumed = websocket_decode_frame(frame, flen, payload, sizeof(payload),
+                                    &plen, &opcode, &fin);
+  assert_int_equal(consumed, flen);
+  assert_int_equal(plen, WS_MAX_PAYLOAD);
+  assert_int_equal(opcode, WS_OPCODE_BINARY);
+  assert_int_equal(payload[WS_MAX_PAYLOAD - 1],
+                   'a' + ((WS_MAX_PAYLOAD - 1) % 26));
+}
+
+static void test_decode_over_max_is_toobig(void **state)
+{
+  static unsigned char frame[WS_MAX_FRAME + 1];
+  static char payload[WS_MAX_PAYLOAD + 2];
+  int flen, consumed, plen, opcode, fin;
+  (void)state;
+
+  flen = build_frame(frame, WS_OPCODE_TEXT, WS_MAX_PAYLOAD + 1);
+  consumed = websocket_decode_frame(frame, flen, payload, sizeof(payload),
+                                    &plen, &opcode, &fin);
+  assert_int_equal(consumed, WS_DECODE_TOOBIG);
+}
+
+/* The pre-fix caller: a BUFSIZE + 16 buffer cannot take a 600-byte frame.
+ * Documents why the buffer in read_packet() must be WS_MAX_PAYLOAD-sized. */
+static void test_decode_small_buffer_rejects(void **state)
+{
+  static unsigned char frame[WS_MAX_FRAME];
+  char payload[BUFSIZE + 16];
+  int flen, consumed, plen, opcode, fin;
+  (void)state;
+
+  flen = build_frame(frame, WS_OPCODE_TEXT, 600);
+  consumed = websocket_decode_frame(frame, flen, payload, sizeof(payload),
+                                    &plen, &opcode, &fin);
+  assert_int_equal(consumed, -1);
+}
+
+static void test_decode_incomplete_frame(void **state)
+{
+  static unsigned char frame[WS_MAX_FRAME];
+  static char payload[WS_MAX_PAYLOAD + 2];
+  int flen, consumed, plen, opcode, fin;
+  (void)state;
+
+  flen = build_frame(frame, WS_OPCODE_TEXT, 2000);
+  /* Everything but the last byte: must ask for more, not error */
+  consumed = websocket_decode_frame(frame, flen - 1, payload, sizeof(payload),
+                                    &plen, &opcode, &fin);
+  assert_int_equal(consumed, 0);
+}
+
+/* ========== websocket_handshake_feed() (#99) ========== */
+
+static void test_handshake_600_bytes_split_reads(void **state)
+{
+  struct Client cli;
+  struct Connection con;
+  static char req[4096];
+  int len, result, consumed;
+  (void)state;
+
+  setup_client(&cli, &con);
+  SetWSNeedHandshake(&cli);
+  len = build_request(req, 600);
+  result = feed_in_chunks(&cli, req, len, 512, &consumed);
+  assert_int_equal(result, 1);
+  assert_int_equal(consumed, len - 512);
+  assert_true(strncmp(sent_buf, "HTTP/1.1 101 ", 13) == 0);
+  assert_non_null(strstr(sent_buf, "Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo="));
+  assert_non_null(strstr(sent_buf, "Sec-WebSocket-Protocol: text.ircv3.net"));
+  assert_true(IsWebSocket(&cli));
+  assert_true(IsWSText(&cli));
+  assert_false(IsWSNeedHandshake(&cli));
+  assert_null(cli_ws_hs_buf(&cli));
+  assert_int_equal(cli_ws_hs_len(&cli), 0);
+}
+
+static void test_handshake_2000_bytes_split_reads(void **state)
+{
+  struct Client cli;
+  struct Connection con;
+  static char req[4096];
+  int len, result, consumed;
+  (void)state;
+
+  setup_client(&cli, &con);
+  len = build_request(req, 2000);
+  result = feed_in_chunks(&cli, req, len, 512, &consumed);
+  assert_int_equal(result, 1);
+  assert_int_equal(consumed, len - 3 * 512);
+  assert_true(strncmp(sent_buf, "HTTP/1.1 101 ", 13) == 0);
+  assert_true(IsWebSocket(&cli));
+  assert_null(cli_ws_hs_buf(&cli));
+}
+
+static void test_handshake_single_read(void **state)
+{
+  struct Client cli;
+  struct Connection con;
+  static char req[4096];
+  int len, result, consumed;
+  (void)state;
+
+  setup_client(&cli, &con);
+  len = build_request(req, 300);
+  result = websocket_handshake_feed(&cli, req, len, &consumed);
+  assert_int_equal(result, 1);
+  assert_int_equal(consumed, len);
+  assert_true(IsWebSocket(&cli));
+}
+
+/* Terminator split across reads: "\r\n\r" then "\n". */
+static void test_handshake_terminator_split(void **state)
+{
+  struct Client cli;
+  struct Connection con;
+  static char req[4096];
+  int len, result, consumed;
+  (void)state;
+
+  setup_client(&cli, &con);
+  len = build_request(req, 700);
+  result = websocket_handshake_feed(&cli, req, len - 1, &consumed);
+  assert_int_equal(result, 0);
+  assert_int_equal(consumed, len - 1);
+  result = websocket_handshake_feed(&cli, req + len - 1, 1, &consumed);
+  assert_int_equal(result, 1);
+  assert_int_equal(consumed, 1);
+  assert_true(IsWebSocket(&cli));
+}
+
+/* An early frame in the same read as the end of the request must be
+ * reported as not consumed so the caller can decode it. */
+static void test_handshake_trailing_frame_not_consumed(void **state)
+{
+  struct Client cli;
+  struct Connection con;
+  static char req[4096];
+  int len, result, consumed;
+  (void)state;
+
+  setup_client(&cli, &con);
+  len = build_request(req, 900);
+  memcpy(req + len, "FRAME", 5);
+  result = feed_in_chunks(&cli, req, len + 5, 512, &consumed);
+  assert_int_equal(result, 1);
+  assert_int_equal(consumed, len - 512);  /* last chunk minus the 5 frame bytes */
+  assert_true(IsWebSocket(&cli));
+}
+
+static void test_handshake_too_large(void **state)
+{
+  struct Client cli;
+  struct Connection con;
+  static char req[WS_HANDSHAKE_MAX + 1024];
+  int result, consumed, off = 0;
+  (void)state;
+
+  setup_client(&cli, &con);
+  /* A request that never ends */
+  memcpy(req, "GET / HTTP/1.1\r\nX-Pad: ", 23);
+  memset(req + 23, 'p', sizeof(req) - 23);
+  do {
+    result = websocket_handshake_feed(&cli, req + off, 512, &consumed);
+    off += 512;
+  } while (result == 0 && off < (int)sizeof(req));
+  assert_int_equal(result, WS_HANDSHAKE_TOOBIG);
+  assert_true(off <= WS_HANDSHAKE_MAX + 512);
+  assert_null(cli_ws_hs_buf(&cli));
+  assert_false(IsWebSocket(&cli));
+}
+
+static void test_handshake_invalid_request(void **state)
+{
+  struct Client cli;
+  struct Connection con;
+  static const char req[] = "GET / HTTP/1.1\r\nHost: x\r\n\r\n";
+  int result, consumed;
+  (void)state;
+
+  setup_client(&cli, &con);
+  result = websocket_handshake_feed(&cli, req, sizeof(req) - 1, &consumed);
+  assert_int_equal(result, -1);
+  assert_null(cli_ws_hs_buf(&cli));
+  assert_false(IsWebSocket(&cli));
+}
+
+int main(void)
+{
+  const struct CMUnitTest tests[] = {
+    cmocka_unit_test(test_decode_600_byte_frame),
+    cmocka_unit_test(test_decode_max_payload_frame),
+    cmocka_unit_test(test_decode_over_max_is_toobig),
+    cmocka_unit_test(test_decode_small_buffer_rejects),
+    cmocka_unit_test(test_decode_incomplete_frame),
+    cmocka_unit_test(test_handshake_600_bytes_split_reads),
+    cmocka_unit_test(test_handshake_2000_bytes_split_reads),
+    cmocka_unit_test(test_handshake_single_read),
+    cmocka_unit_test(test_handshake_terminator_split),
+    cmocka_unit_test(test_handshake_trailing_frame_not_consumed),
+    cmocka_unit_test(test_handshake_too_large),
+    cmocka_unit_test(test_handshake_invalid_request),
+  };
+  return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/ircd/websocket.c
+++ b/ircd/websocket.c
@@ -438,6 +438,84 @@ int websocket_handshake(struct Client *cptr, const char *buffer, int length)
 #endif
 }
 
+/** Accumulate an HTTP upgrade request across reads and run the handshake
+ * once it is complete.
+ *
+ * The request is collected in a per-connection heap buffer of
+ * WS_HANDSHAKE_MAX + 1 bytes, allocated on the first byte and released
+ * as soon as the handshake succeeds or fails (dealloc_connection() also
+ * frees it if the client goes away first).  Real browsers send 500-700
+ * byte upgrade requests, well over the 512-byte cli_buffer that used to
+ * hold it, so the request must be allowed to span several reads.
+ *
+ * @param[in] cptr Client attempting to connect.
+ * @param[in] data Bytes just read.
+ * @param[in] len Number of bytes in \a data.
+ * @param[out] consumed Number of bytes of \a data that belonged to the
+ *   request.  Any bytes after them arrived in the same read as the end
+ *   of the request and are the client's first WebSocket frames; the
+ *   caller must hand them to the frame decoder rather than drop them.
+ * @return 1 if the handshake completed, 0 if more data is needed, -1 if
+ *   the handshake failed, WS_HANDSHAKE_TOOBIG if WS_HANDSHAKE_MAX bytes
+ *   arrived without a terminating blank line.
+ */
+int websocket_handshake_feed(struct Client *cptr, const char *data,
+                             int len, int *consumed)
+{
+  char *buf = cli_ws_hs_buf(cptr);
+  int have = cli_ws_hs_len(cptr);
+  const char *term;
+  int take, req_len, result;
+
+  *consumed = 0;
+
+  if (!buf) {
+    buf = (char *)MyMalloc(WS_HANDSHAKE_MAX + 1);
+    cli_ws_hs_buf(cptr) = buf;
+    have = 0;
+  }
+
+  /* Append what fits; keep the buffer NUL-terminated for strstr() */
+  take = len;
+  if (take > WS_HANDSHAKE_MAX - have)
+    take = WS_HANDSHAKE_MAX - have;
+  if (take > 0)
+    memcpy(buf + have, data, take);
+  have += take;
+  buf[have] = '\0';
+  cli_ws_hs_len(cptr) = have;
+
+  Debug((DEBUG_DEBUG, "WebSocket handshake: +%d bytes, %d buffered", take, have));
+
+  /* Search from the start so a terminator split across reads is found */
+  term = strstr(buf, "\r\n\r\n");
+  if (!term) {
+    if (have >= WS_HANDSHAKE_MAX) {
+      Debug((DEBUG_DEBUG, "WebSocket: upgrade request from %s exceeds %d bytes",
+             cli_sockhost(cptr), WS_HANDSHAKE_MAX));
+      MyFree(buf);
+      cli_ws_hs_buf(cptr) = NULL;
+      cli_ws_hs_len(cptr) = 0;
+      return WS_HANDSHAKE_TOOBIG;
+    }
+    *consumed = take;
+    return 0;  /* need more data */
+  }
+
+  /* Everything past the blank line came from this read: hand it back */
+  req_len = (term + 4) - buf;
+  *consumed = take - (have - req_len);
+  buf[req_len] = '\0';
+
+  result = websocket_handshake(cptr, buf, req_len);
+
+  MyFree(buf);
+  cli_ws_hs_buf(cptr) = NULL;
+  cli_ws_hs_len(cptr) = 0;
+
+  return result;
+}
+
 /** Decode a WebSocket frame and extract the payload.
  * @param[in] frame Raw WebSocket frame data.
  * @param[in] frame_len Length of frame data.

--- a/ircd/websocket.c
+++ b/ircd/websocket.c
@@ -63,9 +63,6 @@
 #define WS_FIN  0x80
 #define WS_MASK 0x80
 
-/* Maximum WebSocket frame payload we'll accept */
-#define WS_MAX_PAYLOAD 16384
-
 /* Subprotocol types */
 #define WS_SUBPROTO_NONE   0  /**< No subprotocol requested by client */
 #define WS_SUBPROTO_BINARY 1
@@ -449,7 +446,8 @@ int websocket_handshake(struct Client *cptr, const char *buffer, int length)
  * @param[out] payload_len Length of decoded payload.
  * @param[out] opcode The frame opcode.
  * @param[out] is_fin Set to 1 if FIN bit is set (final fragment), 0 otherwise.
- * @return Number of bytes consumed from frame, 0 if incomplete, -1 on error.
+ * @return Number of bytes consumed from frame, 0 if incomplete, -1 on
+ *   error, WS_DECODE_TOOBIG if the payload exceeds WS_MAX_PAYLOAD.
  *
  * RFC 6455 Compliance:
  * - §5.2: RSV1-3 bits MUST be 0 unless extension negotiated (we negotiate none)
@@ -531,10 +529,11 @@ int websocket_decode_frame(const unsigned char *frame, int frame_len,
     return -1;
   }
 
-  /* Sanity check payload length */
+  /* Sanity check payload length.  Distinct return so the caller can
+   * answer with Close 1009 instead of a bare TCP drop. */
   if (plen > WS_MAX_PAYLOAD) {
     Debug((DEBUG_DEBUG, "WebSocket: Frame too large: %llu bytes", plen));
-    return -1;
+    return WS_DECODE_TOOBIG;
   }
 
   /* Get mask (required for client-to-server frames - we already verified masked=1 above) */
@@ -632,6 +631,31 @@ static int ws_send_raw(struct Client *cptr, const unsigned char *data, int len)
     unsigned int bytes_sent;
     return (os_send_nonb(cli_fd(cptr), (char *)data, len, &bytes_sent) == IO_SUCCESS) ? 1 : 0;
   }
+}
+
+/** Send a WebSocket Close frame (RFC 6455 §5.5.1) with a status code.
+ * Best effort, no error reporting: this is used immediately before the
+ * connection is dropped so the client can tell a policy close (e.g.
+ * 1009 Message Too Big) apart from a network failure (1006).
+ * @param[in] cptr Client connection.
+ * @param[in] code Status code.
+ * @param[in] reason Optional reason text (truncated to fit a control frame).
+ */
+void websocket_send_close(struct Client *cptr, int code, const char *reason)
+{
+  unsigned char frame[2 + 125];
+  int rlen = reason ? (int)strlen(reason) : 0;
+
+  if (rlen > 123)
+    rlen = 123;  /* control frame payload <= 125 incl. 2-byte code */
+  frame[0] = WS_FIN | WS_OPCODE_CLOSE;
+  frame[1] = (unsigned char)(2 + rlen);
+  frame[2] = (code >> 8) & 0xFF;
+  frame[3] = code & 0xFF;
+  if (rlen > 0)
+    memcpy(frame + 4, reason, rlen);
+  Debug((DEBUG_DEBUG, "WebSocket: sending Close %d (%s)", code, reason ? reason : ""));
+  ws_send_raw(cptr, frame, 4 + rlen);
 }
 
 int websocket_handle_control(struct Client *cptr, int opcode,


### PR DESCRIPTION
Three WebSocket fixes for the `ircv3.2-upgrade` branch, found while bringing up a browser IRCv3 client (Seance, a TheLounge fork) directly against nefarious2 over WebSocket. Each fix is its own commit; the fourth commit adds cmocka coverage.

Fixes #97, fixes #98, fixes #99.

## #97 — auth NOTICEs corrupt the handshake on plain websocket ports

`s_auth.c` `sendheader()` wrote `NOTICE * :*** Looking up your hostname` etc. straight to the fd with `send()`, bypassing the hold in `deliver_it()` that suppresses output while `IsWSNeedHandshake`/`IsWSSniff` is set. On plain ports the notices landed on the wire before the `HTTP/1.1 101`, so no HTTP client would accept the upgrade. TLS ports only worked by accident: `ssl_send()` already goes through `sendrawto_one()`/`send_queued()` (the MsgQ), which the hold applies to.

Fix: `sendheader()` now uses `sendrawto_one()` + `send_queued()` on both paths (the header message table drops its hard-coded CRLF; the msgq adds it), so the notices are held during the handshake and delivered as frames after the `101`.

## #98 — inbound frames ≥ 528 bytes disconnect

`websocket_decode_frame()` allowed `WS_MAX_PAYLOAD` (16 KB) but was handed a `BUFSIZE + 16` stack buffer and rejected any payload ≥ its size, so a single 528-byte frame killed the connection with `WebSocket frame error`. Browsers can't control fragmentation, so this capped every client at ~527 bytes per frame and made `draft/multiline` unusable.

Fix: static decode buffer sized to `WS_MAX_PAYLOAD`; the receive loop now feeds the full 60 KB `readbuf` through the per-connection frame buffer (`con_ws_frame_buf`, grown to `WS_MAX_FRAME`) instead of silently dropping partial frames ≥ 512 bytes and bytes past `BUFSIZE` when a partial was pending. Decoded lines still go through `recv_classify()`/recvQ like TCP input, so an over-long *IRC line* gets the normal treatment; a frame over 16 KB now gets a Close frame `1009 Message too big` (new `websocket_send_close()`) instead of a bare TCP drop.

## #99 — upgrade requests ≥ 512 bytes are never answered

The handshake was only attempted on the bytes that fit in the client's 512-byte `cli_buffer`, so a request whose `\r\n\r\n` fell beyond that (every real browser: ~550–700 bytes with `User-Agent`, `Accept-*`, `Origin`, `Sec-WebSocket-Extensions`, `Sec-Fetch-*`) never completed and the client hung until the registration timeout. Node's ~200-byte request is why CLI probes worked.

Fix: `websocket_handshake_feed()` accumulates the request in a heap buffer (`con_ws_hs_buf`, capped at `WS_HANDSHAKE_MAX` 8192 → `exit_client "WebSocket handshake too large"`), runs the handshake on the complete request and frees the buffer (also freed in `dealloc_connection()`). Bytes after `\r\n\r\n` in the same read (an early frame) are moved to the front of `readbuf` for the decoder instead of being lost; the `autodetect` sniff path feeds its parked bytes first and still works.

## Tests

`ircd/test/websocket_cmocka.c` — 12 cases: 600 B / 16 KB / 16 KB+1 payload decode, the old 528-byte-buffer failure, 600 B and 2000 B handshakes delivered in 512-byte reads, split terminator, trailing-frame `consumed`, > 8 KB reject. All pass in the Docker build (`make test-cmocka`).

Pre-existing and unrelated: `ircd_string_cmocka` `test_ircd_strncpy_truncation` fails on the untouched branch; the Makefile's `| tee` masks it so the build passes regardless.

## Verification (Docker build of this branch, `Port { … websocket = yes; }` plain and `ssl = yes; websocket = yes;`)

| | before | after |
| --- | --- | --- |
| `nc` raw upgrade on plain port | three `NOTICE` lines, then `101` | `101` first, notices framed |
| Node probe `ws://` plain port | `Parse Error: Expected HTTP/` | reaches `001` |
| 600 B / 2000 B single-frame `PRIVMSG` over `wss://` | `WebSocket frame error`, 1006 | accepted |
| 17 KB frame | 1006 | Close `1009 Message too big` |
| padded upgrade requests 600 B / 2000 B | hang | `101` |
| headless Chromium (real 554-byte request) | hang | connects, joins, chats |

Also reproduced the pre-fix behaviour of #99 against a production `3868b34` server (`wss://…:6697`, `websocket = autodetect`): 492-byte request → `101`, 617-byte request → no response.

Two related observations, not changed here:
- `recv_classify.c` caps every client's message body at 512 bytes, so a 600-byte plain `PRIVMSG` is still killed as "Excess Flood: message region too large" — on TCP and WebSocket alike. That's the branch's normal over-length treatment, but it is stricter than `draft/multiline`'s advertised `max-bytes=16384`.
- The TLS listener requests a client certificate (`SSL_VERIFY_PEER|SSL_VERIFY_CLIENT_ONCE`, optional). Interactive browsers cope; headless Chromium aborts with `ERR_SSL_CLIENT_AUTH_CERT_NEEDED`, so automated browser runs need a pass-through TLS proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Tav3uCsxw5mmqHpGNCnbK
