### PR TITLE
fix: burst wipeout leaves +L redirect (and +l limit) active

### DIFF
--- a/ircd/channel.c
+++ b/ircd/channel.c
@@ -4784,12 +4784,25 @@ mode_parse(struct ModeBuf *mbuf, struct Client *cptr, struct Client *sptr,
   }
 
   if (state.flags & MODE_PARSE_WIPEOUT) {
-    if (state.chptr->mode.limit && !(state.done & DONE_LIMIT))
+    /*
+     * The limit and the redirect are special-cased by modebuf_mode_uint()
+     * and modebuf_mode_string(): -l and -L take no parameter, so neither
+     * routine keeps a reference to what we pass it.  That makes it safe to
+     * clear them here, which we must do -- nothing else on the wipeout path
+     * ever will, and both are enforced straight off the stored value.
+     */
+    if (state.chptr->mode.limit && !(state.done & DONE_LIMIT)) {
       modebuf_mode_uint(state.mbuf, MODE_DEL | MODE_LIMIT,
 			state.chptr->mode.limit);
-    if (*state.chptr->mode.redir && !(state.done & DONE_REDIR))
+      if (state.flags & MODE_PARSE_SET)
+        state.chptr->mode.limit = 0;
+    }
+    if (*state.chptr->mode.redir && !(state.done & DONE_REDIR)) {
       modebuf_mode_string(state.mbuf, MODE_DEL | MODE_REDIRECT,
               state.chptr->mode.redir, 0);
+      if (state.flags & MODE_PARSE_SET)
+        *state.chptr->mode.redir = '\0';
+    }
     if (*state.chptr->mode.key && !(state.done & DONE_KEY_DEL))
       modebuf_mode_string(state.mbuf, MODE_DEL | MODE_KEY,
 			  state.chptr->mode.key, 0);


### PR DESCRIPTION
Fixes #46

## The problem

`+L` has no bit in `chptr->mode.mode` — it is stored only as a string. Both enforcement (`ircd/m_join.c:152`) and display (`ircd/channel.c:1137`) test `*chptr->mode.redir` directly, so the redirect is live for exactly as long as that string is non-empty.

The netburst wipeout in `mode_parse()` queued `MODE_DEL | MODE_REDIRECT` on the modebuf and stopped there. The only code that empties the string is `mode_parse_redir()`, which is reached only when an `L` appears in the mode string being parsed — and on the wipeout path the winning (older) side has no `+L`, so it never runs.

Result, as reported: clients see `-L` during the burst, `/check #channel` still shows `+L #target`, and joins keep getting redirected. The stale value is also self-perpetuating — every later wipeout on that channel re-sends a spurious `-L` for a redirect that was never set, which is the second symptom in the issue.

`chptr->mode.limit` is enforced and displayed off its stored value the same way and had the identical miss, so it is fixed in the same block.

## The fix

Clear `mode.redir` and `mode.limit` after queueing their removal, guarded by `MODE_PARSE_SET`.

This is safe in place because `modebuf_mode_uint()` and `modebuf_mode_string()` special-case `MODE_DEL | MODE_LIMIT` and `MODE_DEL | MODE_REDIRECT` (`ircd/channel.c:2694`, `ircd/channel.c:2721`): `-l` and `-L` carry no parameter, so both routines set `mb_rem` and return without retaining what they were handed. The `-k` / `-U` / `-A` cases directly below *do* keep the pointer until flush and are deliberately left untouched.

The sibling wipeout in `ircd/m_join.c:465-478` already clears `limit`, `key`, `upass` and `apass` on a TS change; this brings the burst path in line with it.

## Testing

Compiles clean with `--enable-debug --with-maxcon=4096`, no new warnings. Not exercised against a live netburst.

## Related, not addressed here

- `ircd/m_clearmode.c` has no `'L'` in its mode table, so `CLEARMODE` cannot clear a redirect at all.
- `sub1_from_channel()` (`ircd/channel.c:286-300`) resets `mode`, `limit` and `key` on an emptied channel but leaves `redir` set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PW94seng6gJ41rmDBSbxp