### PR TITLE
fix: reject invalid Spoofhost block hosts at config parse time

### DIFF
--- a/doc/example.conf
+++ b/doc/example.conf
@@ -975,6 +975,12 @@ Port {
 #               of <hostmask> will match against the USER supplied user name
 #               as well as the ident supplied user name. Defaults to yes.
 #
+# NOTE: <spoof host> may only contain characters that are valid in a user name
+#       and a host name, plus * and ? when ismask is enabled. Anything else,
+#       such as a leading ':' or an embedded space, is rejected when the
+#       configuration is read, because it would corrupt the protocol messages
+#       the spoof host is sent in.
+#
 # NOTE: When using ismask steps should be taken to ensure only users you trust
 #       can make use of a Spoofhost block using the option. The reason for this
 #       is because of the nature of ismask, users who can use a Spoofhost block

--- a/include/ircd_string.h
+++ b/include/ircd_string.h
@@ -54,6 +54,7 @@ extern int check_if_ipmask(const char *mask);
 
 extern int valid_username(const char* name);
 extern int valid_hostname(const char* name);
+extern int valid_spoofhost(const char* host, int mask);
 
 #define COLOR_BOLD            2   /**< Bold text */
 #define COLOR_COLOR           3   /**< Color text */

--- a/ircd/ircd_parser.y
+++ b/ircd/ircd_parser.y
@@ -1712,6 +1712,8 @@ spoofhostblock : SPOOFHOST QSTRING
     parse_error("Missing host(s) in spoofhost block");
   else if (spoofhost == NULL)
     parse_error("Missing spoofhost in spoofhost block");
+  else if (!valid_spoofhost(spoofhost, (flags & SHFLAG_ISMASK)))
+    parse_error("Invalid spoofhost '%s' in spoofhost block", spoofhost);
   else for (link = hosts; link != NULL; link = link->next) {
     sconf = (struct SHostConf*) MyCalloc(1, sizeof(*sconf));
     if (!(flags & SHFLAG_NOPASS))

--- a/ircd/ircd_string.c
+++ b/ircd/ircd_string.c
@@ -950,3 +950,48 @@ int valid_hostname(const char* name) {
 
   return 1;
 }
+
+/* Check if a spoof host is valid.  A spoof host is a host name, optionally
+ * prefixed with a user name and '@'.  Wildcards are only allowed if mask is
+ * non-zero (Spoofhost blocks using ismask).  Anything else is rejected so
+ * that the spoof host cannot be mistaken for something other than a single
+ * parameter when it is sent to other servers, most notably a spoof host
+ * beginning with a ':'.
+ */
+int valid_spoofhost(const char* host, int mask) {
+  const char *c = NULL;
+  const char *at = NULL;
+
+  /* Empty strings are not valid spoof hosts */
+  if (EmptyString(host))
+    return 0;
+
+  if ((at = strchr(host, '@')) != NULL) {
+    /* Don't allow an empty user name */
+    if (at == host)
+      return 0;
+    for (c = host; c < at; c++) {
+      if (!IsUserChar(*c) && !(mask && ((*c == '*') || (*c == '?'))))
+        return 0;
+    }
+    c = at + 1;
+  } else
+    c = host;
+
+  /* Empty strings are not valid hosts */
+  if (EmptyString(c))
+    return 0;
+  /* Don't allow leading period */
+  if (*c == '.')
+    return 0;
+  /* Don't allow trailing period */
+  if (c[strlen(c)-1] == '.')
+    return 0;
+
+  for ( ; *c; c++) {
+    if (!IsHostChar(*c) && !(mask && ((*c == '*') || (*c == '?'))))
+      return 0;
+  }
+
+  return 1;
+}


### PR DESCRIPTION
Fixes #60

## The problem

`Spoofhost` blocks are the only place a host string enters the server without validation. `/SETHOST` (`m_sethost.c:126`, `m_sethost.c:183`) and `WEBIRC` (`m_webirc.c:194`) both run `valid_hostname()` on the host they are handed, but the parser (`ircd_parser.y:1698`) copied the quoted spoof host straight into the `SHostConf`, and autoapply (`s_user.c:427`) copied it verbatim into `cli_user()->sethost`.

`:` is not a host character anywhere else in the server — `IsHostChar` is alnum plus `-_.` (`table_gen.c:107`) — so this is the one way a host beginning with `:` can reach the network.

That matters because the sethost is emitted as a **middle** parameter, never a trailing one. `umode_str()` (`s_user.c:1934`) appends it after the mode letters, so it goes out in the burst NICK (`s_serv.c:257`):

```
AB N nick 1 ts user realhost +h <sethost> <b64ip> <numnick> :realname
```

and in live `MODE +h` from `send_umode()` (`s_user.c:2054`). With `Spoofhost ":x@foo.com"`:

```
AB N nick 1 ts user realhost +h :x@foo.com AAAAAA ABAAA :Real Name
                                 ^ the remote parser (parse.c:1626) takes
                                   everything from here as one parameter
```

`parc` is still 8, so the count check in `ms_nick()` (`m_nick.c:307`) passes, and `set_nick_name()` then calls `SetRemoteNumNick()` with `"+h"` as the numeric and `base64toip()` on the real host — a silent desync rather than a clean rejection.

A spoof host with no user name is no better: `":foo.com"` becomes `user@:foo.com`, and `hide_hostmask()` splits it back to a host of `:foo.com`, which then truncates every client numeric that carries the host as a middle parameter — `RPL_WHOISUSER` is `"%s %s %s * :%s"` (`s_err.c:657`), so `311 me nick user :foo.com * :realname` loses the tail. An embedded space is worse still, injecting an extra parameter outright. (#59 shows the same gap from the other side: that reporter got colour codes into a spoof host.)

## The fix

Add `valid_spoofhost()` next to `valid_username()`/`valid_hostname()` in `ircd_string.c`, and call it from the `Spoofhost` block. A bad spoof host is reported with the usual parse error and the block is skipped, so it never reaches a client or the wire; the rest of the config still loads.

Wildcards are accepted only when `ismask` is enabled. In that case the spoof host is a mask matched against a host the client supplies — and that host has already been through `valid_hostname()` in `m_sethost.c` — rather than a host applied as-is.

## Testing

Built clean. Config check against a test config, showing the bad blocks rejected while the valid literal and the `ismask` wildcard block load:

```
$ ircd -k -f test.conf
Config parse error ... on line 5: Invalid spoofhost ':evil@example.org' in spoofhost block
Config parse error ... on line 8: Invalid spoofhost 'bad host@example.org' in spoofhost block
```

Also exercised `valid_spoofhost()` directly against the built object over 24 cases — leading `:` in both the bare and `user@host` forms, embedded spaces, control/colour codes, empty user or host part, leading/trailing `.`, IPv6 literals, and wildcards with and without `ismask` — all as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PW94seng6gJ41rmDBSbxp